### PR TITLE
Update to support latest Content Warning version

### DIFF
--- a/ShopUtils/ItemUtils/GameHandlerPatches.cs
+++ b/ShopUtils/ItemUtils/GameHandlerPatches.cs
@@ -14,8 +14,7 @@ namespace ShopUtils.ItemUtils
             Items.InitAllItems();
 
             ItemDatabase item = SingletonAsset<ItemDatabase>.Instance;
-            item.Objects = item.Objects
-                .AddRangeToArray(Items.registerItems.Where(i => i.id != 0).ToArray());
+            item.Objects.AddRange(Items.registerItems.Where(i => i.id != 0));
         }
     }
 }

--- a/ShopUtils/ItemUtils/RoundSpawnerPatch.cs
+++ b/ShopUtils/ItemUtils/RoundSpawnerPatch.cs
@@ -7,7 +7,7 @@ namespace ShopUtils.ItemUtils
     internal static class RoundArtifactSpawnerPatch
     {
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(RoundArtifactSpawner.SpawnRound))]
+        [HarmonyPatch(typeof(RoundArtifactSpawner), "SpawnRound")]
         private static void SpawnRound(RoundArtifactSpawner __instance)
         {
             __instance.possibleSpawns = __instance.possibleSpawns


### PR DESCRIPTION
In the most recent versions of the game, this mod breaks item tooltips on the top right for all items. Even vanilla items, so you can't see film or battery life or anything. This is because the game changed the tooltip function sometime in the past.

This should allow the code to conform to new function parameters, and also add error handling so any future bugs will not result in the UI breaking for vanilla items.